### PR TITLE
Revert "needs_ci should add both needs_ci and needs_ci:3.11"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,7 +123,7 @@ if [[ $comment_body == "needs_ci" ]]; then
   fi
 fi
 
-if [[ $comment_body == "needs_ci:3.11" || $comment_body == "needs_ci" ]]; then
+if [[ $comment_body == "needs_ci:3.11" ]]; then
   for label in $labels; do
     case $label in
       "ci_verified:3.11")


### PR DESCRIPTION
deprecate python 3.8 in CI