### PR TITLE
Added check for "sudo shipit" command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ if [[ "$action" != "created" ]]; then
   exit 0
 fi
 
-if [[ $comment_body == "shipit" || $comment_body == ":shipit:" || $comment_body == ":shipit: " ]]; then
+if [[ $comment_body == "shipit" || $comment_body == ":shipit:" || $comment_body == ":shipit: " || $comment_body == "sudo shipit"* || $comment_body == "sudo :shipit:"* ]]; then
   for label in $labels; do
     case $label in
       ci_verified)


### PR DESCRIPTION
* Added check for the "sudo shipit" and "sudo :shipit:" command, which will also support sudo shipit command provided with reason.
* Shipit label will be added to the PR if "sudo shipit" or "sudo :shipit:" or "sudo shipit 'reason for force merging'" or "sudo :shipit: 'reason for force merging'" is present in the comment body.

# TEST
Tested the if condition locally with different inputs for the comment body

<img width="1255" alt="image" src="https://github.com/EightfoldAI/comment_actions/assets/162978848/36378f31-b4d0-4298-8f3c-cba6cca19bda">
