### PR TITLE
Strip spaces/newlines from comments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,6 @@ AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 # action
 action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 comment_body=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH")
-comment_body=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH")
 # Trim leading/trailing spaces and newlines
 comment_body=$(echo "$comment_body" | xargs) 
 number=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,9 @@ AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 # action
 action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 comment_body=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH")
+comment_body=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH")
+# Trim leading/trailing spaces and newlines
+comment_body=$(echo "$comment_body" | xargs) 
 number=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
 labels=$(jq --raw-output .issue.labels[].name "$GITHUB_EVENT_PATH")
 


### PR DESCRIPTION
```
 2024-10-04 18:44:30 ⌚  ip-172-31-27-73 in ~/vscode
± |pranjal/restrict_external_employees_s3_access {53} ✓| → comment_body=$'sandbox\n'

 2024-10-04 18:44:34 ⌚  ip-172-31-27-73 in ~/vscode
± |pranjal/restrict_external_employees_s3_access {53} ✓| → echo $comment_body
sandbox

 2024-10-04 18:44:40 ⌚  ip-172-31-27-73 in ~/vscode
± |pranjal/restrict_external_employees_s3_access {53} ✓| → comment_body=$(echo "$comment_body" | xargs)

 2024-10-04 18:44:50 ⌚  ip-172-31-27-73 in ~/vscode
± |pranjal/restrict_external_employees_s3_access {53} ✓| → echo $comment_body
sandbox
```