### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 comment_body=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH")
 # Trim newlines, carriage returns and leading/trailing spaces
-comment_body=$(echo "$comment" | grep -v '^[[:space:]]*$' | tr -d '\r' | tr -d '\n'| xargs)
+comment_body=$(echo "$comment_body" | grep -v '^[[:space:]]*$' | tr -d '\r' | tr -d '\n'| xargs)
 number=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
 labels=$(jq --raw-output .issue.labels[].name "$GITHUB_EVENT_PATH")
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,8 +47,8 @@ AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 # action
 action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 comment_body=$(jq --raw-output .comment.body "$GITHUB_EVENT_PATH")
-# Trim leading/trailing spaces and newlines
-comment_body=$(echo "$comment_body" | xargs) 
+# Trim newlines, carriage returns and leading/trailing spaces
+comment_body=$(echo "$comment" | grep -v '^[[:space:]]*$' | tr -d '\r' | tr -d '\n'| xargs)
 number=$(jq --raw-output .issue.number "$GITHUB_EVENT_PATH")
 labels=$(jq --raw-output .issue.labels[].name "$GITHUB_EVENT_PATH")
 


### PR DESCRIPTION
Handle newlines, carriage returns in comments.

ran following script to test changes
it considers comments from https://github.com/EightfoldAI/vscode/pull/67675
```

# Fetch all comments from the PR
comments=$(curl -s -H "Accept: application/vnd.github.v3.sha" -H "Authorization: token ${GIT_AUTH_TOKEN}" https://api.github.com/repos/EightfoldAI/vscode/issues/67675/comments | jq -r '.[].body')

# Iterate over each comment
while IFS= read -r comment; do
    # Check if the raw comment is "needs_sandbox"
    if [[ "$comment" == "needs_ci" ]]; then
        echo "comment raw is needs_ci"
    fi

    echo "$comment"

    # Clean up the comment body by removing carriage returns and trimming whitespace
    comment_body=$(echo "$comment" | grep -v '^[[:space:]]*$' | tr -d '\r' | tr -d '\n'| xargs)

    # Check if the cleaned-up comment body is "needs_sandbox"
    if [[ "$comment_body" == "needs_ci" ]]; then
        echo "comment is needs_ci"
    fi
done <<< "$comments"

```

```
needs_ci      
comment is needs_ci
needs_ci     
comment is needs_ci


needs_ci
comment is needs_ci

```