### PR TITLE
Add Generic CI python version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,7 +64,7 @@ already_verified=false
 already_verified_alt=false
 already_needs_ci_lite=false
 already_needs_ci_alt_lite=false
-alt_python_version="3.13"
+alt_python_version=":3.13"
 
 if [[ "$action" != "created" ]]; then
   echo This action should only be called when a comment is created on a pull request
@@ -84,7 +84,7 @@ if [[ $comment_body == "shipit" || $comment_body == ":shipit:" || $comment_body 
       needs_ci)
         already_needs_ci=true
         ;;
-      # needs_ci:${alt_python_version})
+      # needs_ci${alt_python_version})
       #   already_needs_ci_alt=true
       #   ;;
       *)
@@ -96,7 +96,7 @@ if [[ $comment_body == "shipit" || $comment_body == ":shipit:" || $comment_body 
     add_label "needs_ci"
   fi
   # if [[ "$already_verified_alt" == false && "$already_needs_ci_alt" == false ]]; then
-  #   add_label "needs_ci:${alt_python_version}"
+  #   add_label "needs_ci${alt_python_version}"
   # fi
   if [[ "$already_shipit" == false ]]; then
     add_label "shipit"
@@ -142,13 +142,13 @@ if [[ $comment_body == "needs_ci:lite" ]]; then
   fi
 fi
 
-if [[ $comment_body == "needs_ci:${alt_python_version}" ]]; then
+if [[ $comment_body == "needs_ci${alt_python_version}" ]]; then
   for label in $labels; do
     case $label in
-      "ci_verified:${alt_python_version}")
+      "ci_verified${alt_python_version}")
         remove_label "$label"
         ;;
-      "needs_ci:${alt_python_version}")
+      "needs_ci${alt_python_version}")
         already_needs_ci_alt=true
         ;;
       *)
@@ -157,17 +157,17 @@ if [[ $comment_body == "needs_ci:${alt_python_version}" ]]; then
     esac
   done
   if [[ "$already_needs_ci_alt" == false ]]; then
-    add_label "needs_ci:${alt_python_version}"
+    add_label "needs_ci${alt_python_version}"
   fi
 fi
 
-if [[ $comment_body == "needs_ci:${alt_python_version}:lite" ]]; then
+if [[ $comment_body == "needs_ci${alt_python_version}:lite" ]]; then
   for label in $labels; do
     case $label in
-      ci_verified:${alt_python_version}:lite)
+      ci_verified${alt_python_version}:lite)
         remove_label "$label"
         ;;
-      needs_ci:${alt_python_version}:lite)
+      needs_ci${alt_python_version}:lite)
         already_needs_ci_alt_lite=true
         ;;
       *)
@@ -176,7 +176,7 @@ if [[ $comment_body == "needs_ci:${alt_python_version}:lite" ]]; then
     esac
   done
   if [[ "$already_needs_ci_alt_lite" == false ]]; then
-    add_label "needs_ci:${alt_python_version}:lite"
+    add_label "needs_ci${alt_python_version}:lite"
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,6 +113,9 @@ if [[ $comment_body == "needs_ci" ]]; then
       needs_ci)
         already_needs_ci=true
         ;;
+      "needs_ci${alt_python_version}")
+        already_needs_ci_alt_python_version=true
+        ;;
       *)
         echo "Unknown label $label"
         ;;
@@ -120,6 +123,9 @@ if [[ $comment_body == "needs_ci" ]]; then
   done
   if [[ "$already_needs_ci" == false ]]; then
     add_label "needs_ci"
+  fi
+  if [[ "$already_needs_ci_alt_python_version" == false ]]; then
+    add_label "needs_ci${alt_python_version}"
   fi
 fi
 
@@ -132,6 +138,9 @@ if [[ $comment_body == "needs_ci:lite" ]]; then
       needs_ci:lite)
         already_needs_ci_lite=true
         ;;
+      "needs_ci${alt_python_version}":lite)
+        already_needs_ci_lite_alt_python_version=true
+        ;;
       *)
         echo "Unknown label $label"
         ;;
@@ -139,6 +148,9 @@ if [[ $comment_body == "needs_ci:lite" ]]; then
   done
   if [[ "$already_needs_ci_lite" == false ]]; then
     add_label "needs_ci:lite"
+  fi
+  if [[ "$already_needs_ci_lite_alt_python_version" == false ]]; then
+    add_label "needs_ci${alt_python_version}:lite"
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,20 +57,21 @@ echo $comment_body
 echo $number
 echo $labels
 
-already_needs_ci_3_13=false
+already_needs_ci_alt=false
 already_needs_ci=false
 already_shipit=false
 already_verified=false
-already_verified_3_13=false
+already_verified_alt=false
 already_needs_ci_lite=false
-already_needs_ci_3_13_lite=false
+already_needs_ci_alt_lite=false
+alt_python_version="3.13"
 
 if [[ "$action" != "created" ]]; then
   echo This action should only be called when a comment is created on a pull request
   exit 0
 fi
 
-# TO DO: Uncomment CI 3.13 to make it blocking
+# TODO: Uncomment CI alt to make it blocking
 if [[ $comment_body == "shipit" || $comment_body == ":shipit:" || $comment_body == ":shipit: " || $comment_body == "sudo shipit"* || $comment_body == "sudo :shipit:"* ]]; then
   for label in $labels; do
     case $label in
@@ -83,8 +84,8 @@ if [[ $comment_body == "shipit" || $comment_body == ":shipit:" || $comment_body 
       needs_ci)
         already_needs_ci=true
         ;;
-      # needs_ci:3.13)
-      #   already_needs_ci_3_13=true
+      # needs_ci:${alt_python_version})
+      #   already_needs_ci_alt=true
       #   ;;
       *)
         echo "Unknown label $label"
@@ -94,8 +95,8 @@ if [[ $comment_body == "shipit" || $comment_body == ":shipit:" || $comment_body 
   if [[ "$already_verified" == false && "$already_needs_ci" == false ]]; then
     add_label "needs_ci"
   fi
-  # if [[ "$already_verified_3_13" == false && "$already_needs_ci_3_13" == false ]]; then
-  #   add_label "needs_ci:3.13"
+  # if [[ "$already_verified_alt" == false && "$already_needs_ci_alt" == false ]]; then
+  #   add_label "needs_ci:${alt_python_version}"
   # fi
   if [[ "$already_shipit" == false ]]; then
     add_label "shipit"
@@ -141,41 +142,41 @@ if [[ $comment_body == "needs_ci:lite" ]]; then
   fi
 fi
 
-if [[ $comment_body == "needs_ci:3.13" ]]; then
+if [[ $comment_body == "needs_ci:${alt_python_version}" ]]; then
   for label in $labels; do
     case $label in
-      "ci_verified:3.13")
+      "ci_verified:${alt_python_version}")
         remove_label "$label"
         ;;
-      "needs_ci:3.13")
-        already_needs_ci_3_13=true
+      "needs_ci:${alt_python_version}")
+        already_needs_ci_alt=true
         ;;
       *)
         echo "Unknown label $label"
         ;;
     esac
   done
-  if [[ "$already_needs_ci_3_13" == false ]]; then
-    add_label "needs_ci:3.13"
+  if [[ "$already_needs_ci_alt" == false ]]; then
+    add_label "needs_ci:${alt_python_version}"
   fi
 fi
 
-if [[ $comment_body == "needs_ci:3.13:lite" ]]; then
+if [[ $comment_body == "needs_ci:${alt_python_version}:lite" ]]; then
   for label in $labels; do
     case $label in
-      ci_verified:3.13:lite)
+      ci_verified:${alt_python_version}:lite)
         remove_label "$label"
         ;;
-      needs_ci:3.13:lite)
-        already_needs_ci_3_13_lite=true
+      needs_ci:${alt_python_version}:lite)
+        already_needs_ci_alt_lite=true
         ;;
       *)
         echo "Unknown label $label"
         ;;
     esac
   done
-  if [[ "$already_needs_ci_3_13_lite" == false ]]; then
-    add_label "needs_ci:3.13:lite"
+  if [[ "$already_needs_ci_alt_lite" == false ]]; then
+    add_label "needs_ci:${alt_python_version}:lite"
   fi
 fi
 


### PR DESCRIPTION
To simplify the process, instead of deleting or reverting changes, added an alternate python version that can be edited for future version upgrades.
The other pieces of code can be simply commented as required, or alternate version can be left blank (won't cause an error as colon is to be included with the alt version).
It will work as normal and code won't have to be commented out, as existing functionality would not allow for repeated labels
