### PR TITLE
Adding labels to support airflow sandbox

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -335,3 +335,35 @@ if [[ $comment_body == "stop_sandbox" ]]; then
     esac
   done
 fi
+
+# Add airflow_sandbox if needs_airflow_sandbox
+already_needs_airflow_sandbox=false
+
+if [[ $comment_body == "needs_airflow_sandbox" ]]; then
+  for label in $labels; do
+    case $label in
+      airflow_sandbox)
+        already_needs_airflow_sandbox=true
+        ;;
+      *)
+        echo "Unknown label $label"
+        ;;
+    esac
+  done
+  if [[ "$already_needs_airflow_sandbox" == false ]]; then
+    add_label "airflow_sandbox"
+  fi
+fi
+
+if [[ $comment_body == "stop_airflow_sandbox" ]]; then
+  for label in $labels; do
+    case $label in
+      airflow_sandbox)
+        remove_label "airflow_sandbox"
+        ;;
+      *)
+        echo "Unknown label $label"
+        ;;
+    esac
+  done
+fi


### PR DESCRIPTION
This PR is to edit the entrypoint to support airflow sandbox. Adding 'needs_airflow_sandbox' to add a label 'airflow_sandbox' and adding "stop_airflow_sandbox" to remove that label.