### PR TITLE
Add e2e_needs_sandbox labeler support for local processor sandbox

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 # Varun Chopra <vchopra@eightfold.ai>
 #
 # This action runs every time a comment is added to a pull request.
-# Accepts the following commands: shipit, needs_ci, needs_sandbox
+# Accepts the following commands: shipit, needs_ci, needs_sandbox, e2e_needs_sandbox
 
 set -e
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -205,7 +205,7 @@ already_needs_alternate_version_sandbox=false
 alternate_python_version="3.13"
 current_python_version="3.13"
 
-if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
+if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
   for label in $labels; do
     case $label in
       sandbox:${alternate_python_version})
@@ -252,7 +252,7 @@ if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|
     fi
   fi
 
-elif [[ $comment_body =~ ^needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
+elif [[ $comment_body =~ ^needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
   for label in $labels; do
     case $label in
       sandbox)
@@ -293,6 +293,105 @@ elif [[ $comment_body =~ ^needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(
     elif [[ $comment_body =~ needs_sandbox:wu  ]]; then
       add_label "sandbox :us:"
     elif [[ $comment_body =~ needs_sandbox:ap  ]]; then
+      add_label "sandbox :australia:"
+    else
+      add_label "sandbox"
+    fi
+  fi
+fi
+
+# Add sandbox label for e2e_needs_sandbox (enables local processor in sandbox)
+already_needs_e2e_sandbox=false
+already_needs_alternate_version_e2e_sandbox=false
+
+if [[ $comment_body =~ ^e2e_needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
+  for label in $labels; do
+    case $label in
+      sandbox:${alternate_python_version})
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox:${alternate_python_version} :united_arab_emirates:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox:${alternate_python_version} :eu:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox:${alternate_python_version} :maple_leaf:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox:${alternate_python_version} :classical_building:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox:${alternate_python_version} :us:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox:${alternate_python_version} :australia:")
+        already_needs_e2e_sandbox=true
+        ;;
+      *)
+        echo "Unknown label $label"
+        ;;
+    esac
+  done
+  if [[ "$already_needs_e2e_sandbox" == false && "$current_python_version" != "$alternate_python_version" ]]; then
+    if [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:eu ]]; then
+      add_label "sandbox:${alternate_python_version} :eu:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:ca ]]; then
+      add_label "sandbox:${alternate_python_version} :maple_leaf:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:gov ]]; then
+      add_label "sandbox:${alternate_python_version} :classical_building:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:uae ]]; then
+      add_label "sandbox:${alternate_python_version} :united_arab_emirates:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:wu ]]; then
+      add_label "sandbox:${alternate_python_version} :us:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:ap ]]; then
+      add_label "sandbox:${alternate_python_version} :australia:"
+    else
+      add_label "sandbox:${alternate_python_version}"
+    fi
+  fi
+
+elif [[ $comment_body =~ ^e2e_needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
+  for label in $labels; do
+    case $label in
+      sandbox)
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox :united_arab_emirates:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox :eu:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox :maple_leaf:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox :classical_building:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox :us:")
+        already_needs_e2e_sandbox=true
+        ;;
+      "sandbox :australia:")
+        already_needs_e2e_sandbox=true
+        ;;
+      *)
+        echo "Unknown label $label"
+        ;;
+    esac
+  done
+  if [[ "$already_needs_e2e_sandbox" == false ]]; then
+    if [[ $comment_body =~ e2e_needs_sandbox:eu ]]; then
+      add_label "sandbox :eu:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:ca ]]; then
+      add_label "sandbox :maple_leaf:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:gov ]]; then
+      add_label "sandbox :classical_building:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:uae ]]; then
+      add_label "sandbox :united_arab_emirates:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:wu ]]; then
+      add_label "sandbox :us:"
+    elif [[ $comment_body =~ e2e_needs_sandbox:ap ]]; then
       add_label "sandbox :australia:"
     else
       add_label "sandbox"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -205,7 +205,7 @@ already_needs_alternate_version_sandbox=false
 alternate_python_version="3.13"
 current_python_version="3.13"
 
-if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
+if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
   for label in $labels; do
     case $label in
       sandbox:${alternate_python_version})
@@ -252,7 +252,7 @@ if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|
     fi
   fi
 
-elif [[ $comment_body =~ ^needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
+elif [[ $comment_body =~ ^needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
   for label in $labels; do
     case $label in
       sandbox)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -198,14 +198,13 @@ if [[ $comment_body == "needs_ci${alt_python_version}:lite" ]]; then
   fi
 fi
 
-# Add sandbox is needs_sandbox
-# Remove stop_sandbox if sandbox is requested again
+# Add sandbox label for needs_sandbox and e2e_needs_sandbox (e2e_ prefix enables local processor)
 already_needs_sandbox=false
 already_needs_alternate_version_sandbox=false
 alternate_python_version="3.13"
 current_python_version="3.13"
 
-if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
+if [[ $comment_body =~ ^(e2e_)?needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
   for label in $labels; do
     case $label in
       sandbox:${alternate_python_version})
@@ -235,24 +234,24 @@ if [[ $comment_body =~ ^needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|
     esac
   done
   if [[ "$already_needs_sandbox" == false && "$current_python_version" != "$alternate_python_version" ]]; then
-    if [[ $comment_body =~ needs_sandbox:${alternate_python_version}:eu  ]]; then
+    if [[ $comment_body =~ (e2e_)?needs_sandbox:${alternate_python_version}:eu ]]; then
       add_label "sandbox:${alternate_python_version} :eu:"
-    elif [[ $comment_body =~ needs_sandbox:${alternate_python_version}:ca ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:${alternate_python_version}:ca ]]; then
       add_label "sandbox:${alternate_python_version} :maple_leaf:"
-    elif [[ $comment_body =~ needs_sandbox:${alternate_python_version}:gov  ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:${alternate_python_version}:gov ]]; then
       add_label "sandbox:${alternate_python_version} :classical_building:"
-    elif [[ $comment_body =~ needs_sandbox:${alternate_python_version}:uae  ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:${alternate_python_version}:uae ]]; then
       add_label "sandbox:${alternate_python_version} :united_arab_emirates:"
-    elif [[ $comment_body =~ needs_sandbox:${alternate_python_version}:wu  ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:${alternate_python_version}:wu ]]; then
       add_label "sandbox:${alternate_python_version} :us:"
-    elif [[ $comment_body =~ needs_sandbox:${alternate_python_version}:ap  ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:${alternate_python_version}:ap ]]; then
       add_label "sandbox:${alternate_python_version} :australia:"
     else
       add_label "sandbox:${alternate_python_version}"
     fi
   fi
 
-elif [[ $comment_body =~ ^needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
+elif [[ $comment_body =~ ^(e2e_)?needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?([ \t]*)?$ ]]; then
   for label in $labels; do
     case $label in
       sandbox)
@@ -282,116 +281,17 @@ elif [[ $comment_body =~ ^needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(
     esac
   done
   if [[ "$already_needs_sandbox" == false ]]; then
-    if [[ $comment_body =~ needs_sandbox:eu  ]]; then
+    if [[ $comment_body =~ (e2e_)?needs_sandbox:eu ]]; then
       add_label "sandbox :eu:"
-    elif [[ $comment_body =~ needs_sandbox:ca ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:ca ]]; then
       add_label "sandbox :maple_leaf:"
-    elif [[ $comment_body =~ needs_sandbox:gov  ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:gov ]]; then
       add_label "sandbox :classical_building:"
-    elif [[ $comment_body =~ needs_sandbox:uae  ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:uae ]]; then
       add_label "sandbox :united_arab_emirates:"
-    elif [[ $comment_body =~ needs_sandbox:wu  ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:wu ]]; then
       add_label "sandbox :us:"
-    elif [[ $comment_body =~ needs_sandbox:ap  ]]; then
-      add_label "sandbox :australia:"
-    else
-      add_label "sandbox"
-    fi
-  fi
-fi
-
-# Add sandbox label for e2e_needs_sandbox (enables local processor in sandbox)
-already_needs_e2e_sandbox=false
-already_needs_alternate_version_e2e_sandbox=false
-
-if [[ $comment_body =~ ^e2e_needs_sandbox(:${alternate_python_version})(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
-  for label in $labels; do
-    case $label in
-      sandbox:${alternate_python_version})
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox:${alternate_python_version} :united_arab_emirates:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox:${alternate_python_version} :eu:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox:${alternate_python_version} :maple_leaf:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox:${alternate_python_version} :classical_building:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox:${alternate_python_version} :us:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox:${alternate_python_version} :australia:")
-        already_needs_e2e_sandbox=true
-        ;;
-      *)
-        echo "Unknown label $label"
-        ;;
-    esac
-  done
-  if [[ "$already_needs_e2e_sandbox" == false && "$current_python_version" != "$alternate_python_version" ]]; then
-    if [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:eu ]]; then
-      add_label "sandbox:${alternate_python_version} :eu:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:ca ]]; then
-      add_label "sandbox:${alternate_python_version} :maple_leaf:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:gov ]]; then
-      add_label "sandbox:${alternate_python_version} :classical_building:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:uae ]]; then
-      add_label "sandbox:${alternate_python_version} :united_arab_emirates:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:wu ]]; then
-      add_label "sandbox:${alternate_python_version} :us:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:${alternate_python_version}:ap ]]; then
-      add_label "sandbox:${alternate_python_version} :australia:"
-    else
-      add_label "sandbox:${alternate_python_version}"
-    fi
-  fi
-
-elif [[ $comment_body =~ ^e2e_needs_sandbox(:(eu|gov|ca|uae|wu|ap))?(:(dev|([0-9]+)(\.([0-9]+)?)?))?(:(([a-zA-Z0-9,]+)))?(:_processor)?([ \t]*)?$ ]]; then
-  for label in $labels; do
-    case $label in
-      sandbox)
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox :united_arab_emirates:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox :eu:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox :maple_leaf:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox :classical_building:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox :us:")
-        already_needs_e2e_sandbox=true
-        ;;
-      "sandbox :australia:")
-        already_needs_e2e_sandbox=true
-        ;;
-      *)
-        echo "Unknown label $label"
-        ;;
-    esac
-  done
-  if [[ "$already_needs_e2e_sandbox" == false ]]; then
-    if [[ $comment_body =~ e2e_needs_sandbox:eu ]]; then
-      add_label "sandbox :eu:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:ca ]]; then
-      add_label "sandbox :maple_leaf:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:gov ]]; then
-      add_label "sandbox :classical_building:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:uae ]]; then
-      add_label "sandbox :united_arab_emirates:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:wu ]]; then
-      add_label "sandbox :us:"
-    elif [[ $comment_body =~ e2e_needs_sandbox:ap ]]; then
+    elif [[ $comment_body =~ (e2e_)?needs_sandbox:ap ]]; then
       add_label "sandbox :australia:"
     else
       add_label "sandbox"


### PR DESCRIPTION
## Summary

Adds labeler support for the new `e2e_needs_sandbox` comment form introduced in [vscode#100917](https://github.com/EightfoldAI/vscode/pull/100917).

- `e2e_needs_sandbox` (and region/time/app variants) now trigger the same `sandbox` labels as `needs_sandbox`
- The `e2e_` prefix signals the GitHub bot to start a local processor alongside the sandbox
- Updated script header to document `e2e_needs_sandbox` as a supported command

## Supported comment forms

| Comment | Label added |
|---|---|
| `e2e_needs_sandbox` | `sandbox` |
| `e2e_needs_sandbox:eu` | `sandbox :eu:` |
| `e2e_needs_sandbox:10:taPwa` | `sandbox` |
| `e2e_needs_sandbox:3.13` | `sandbox:3.13` |